### PR TITLE
Add custom argument representation handling

### DIFF
--- a/redis/conn.go
+++ b/redis/conn.go
@@ -322,6 +322,10 @@ func (c *conn) writeCommand(cmd string, args []interface{}) (err error) {
 			}
 		case nil:
 			err = c.writeString("")
+		case Argument:
+			var buf bytes.Buffer
+			fmt.Fprint(&buf, arg.RedisArg())
+			err = c.writeBytes(buf.Bytes())
 		default:
 			var buf bytes.Buffer
 			fmt.Fprint(&buf, arg)

--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -46,6 +46,14 @@ func dialTestConn(r io.Reader, w io.Writer) redis.DialOption {
 	})
 }
 
+type durationArg struct {
+	time.Duration
+}
+
+func (t durationArg) RedisArg() interface{} {
+	return t.Seconds()
+}
+
 var writeTests = []struct {
 	args     []interface{}
 	expected string
@@ -81,6 +89,10 @@ var writeTests = []struct {
 	{
 		[]interface{}{"SET", "key", nil},
 		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$0\r\n\r\n",
+	},
+	{
+		[]interface{}{"SET", "key", durationArg{time.Minute}},
+		"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$2\r\n60\r\n",
 	},
 	{
 		[]interface{}{"ECHO", true, false},

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -42,3 +42,11 @@ type Conn interface {
 	// Receive receives a single reply from the Redis server
 	Receive() (reply interface{}, err error)
 }
+
+// Argument is implemented by types which want to control how their value is
+// interpreted when used as an argument to a redis command.
+type Argument interface {
+	// RedisArg returns the interface that represents the value to be used
+	// in redis commands.
+	RedisArg() interface{}
+}


### PR DESCRIPTION
Add the ability for types to control how they are sent when used as arguments to redis commands.

This is useful for types which don't want to use their Stringer representation when used as an argument to a redis command.

Examples of this is a time.Duration which the user wants to store the number of seconds or a time.Time being stored as int instead of a string.
