### PR TITLE
Add custom scan handling

### DIFF
--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -459,7 +459,7 @@ var dialErrors = []struct {
 		"localhost",
 		"invalid redis URL scheme",
 	},
-	// The error message for invalid hosts is diffferent in different
+	// The error message for invalid hosts is different in different
 	// versions of Go, so just check that there is an error message.
 	{
 		"redis://weird url",

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -50,3 +50,13 @@ type Argument interface {
 	// in redis commands.
 	RedisArg() interface{}
 }
+
+// Scanner is implemented by types which want to control how their value is
+// interpreted when read from redis.
+type Scanner interface {
+	// RedisScan assigns a value from a redis value.
+	//
+	// An error should be returned if the value cannot be stored without
+	// loss of information.
+	RedisScan(src interface{}) error
+}

--- a/redis/scan.go
+++ b/redis/scan.go
@@ -110,6 +110,25 @@ func convertAssignInt(d reflect.Value, s int64) (err error) {
 }
 
 func convertAssignValue(d reflect.Value, s interface{}) (err error) {
+	if d.Kind() != reflect.Ptr {
+		if d.CanAddr() {
+			d2 := d.Addr()
+			if d2.CanInterface() {
+				if scanner, ok := d2.Interface().(Scanner); ok {
+					return scanner.RedisScan(s)
+				}
+			}
+		}
+	} else if d.CanInterface() {
+		// Already a reflect.Ptr
+		if d.IsNil() {
+			d.Set(reflect.New(d.Type().Elem()))
+		}
+		if scanner, ok := d.Interface().(Scanner); ok {
+			return scanner.RedisScan(s)
+		}
+	}
+
 	switch s := s.(type) {
 	case []byte:
 		err = convertAssignBulkString(d, s)
@@ -135,11 +154,15 @@ func convertAssignArray(d reflect.Value, s []interface{}) error {
 }
 
 func convertAssign(d interface{}, s interface{}) (err error) {
+	if scanner, ok := d.(Scanner); ok {
+		return scanner.RedisScan(s)
+	}
+
 	// Handle the most common destination types using type switches and
 	// fall back to reflection for all other types.
 	switch s := s.(type) {
 	case nil:
-		// ingore
+		// ignore
 	case []byte:
 		switch d := d.(type) {
 		case *string:
@@ -214,6 +237,8 @@ func convertAssign(d interface{}, s interface{}) (err error) {
 }
 
 // Scan copies from src to the values pointed at by dest.
+//
+// Scan uses RedisScan if available otherwise:
 //
 // The values pointed at by dest must be an integer, float, boolean, string,
 // []byte, interface{} or slices of these types. Scan uses the standard strconv
@@ -355,6 +380,7 @@ var errScanStructValue = errors.New("redigo.ScanStruct: value must be non-nil po
 //
 // Fields with the tag redis:"-" are ignored.
 //
+// Each field uses RedisScan if available otherwise:
 // Integer, float, boolean, string and []byte fields are supported. Scan uses the
 // standard strconv package to convert bulk string values to numeric and
 // boolean types.


### PR DESCRIPTION
Add the ability for types to control how they are read / scanned from redis.

This is useful for types which don't want to use the standard representation i.e. standard strconv methods, when read from redis.

Examples of this is a time.Time stored in a specific format.