### PR TITLE
Enable keep-alive on server connections

### DIFF
--- a/redis/test_test.go
+++ b/redis/test_test.go
@@ -38,6 +38,7 @@ var (
 	ErrNegativeInt = errNegativeInt
 
 	serverPath     = flag.String("redis-server", "redis-server", "Path to redis server binary")
+	serverAddress  = flag.String("redis-address", "127.0.0.1", "The address of the server")
 	serverBasePort = flag.Int("redis-port", 16379, "Beginning of port range for test servers")
 	serverLogName  = flag.String("redis-log", "", "Write Redis server logs to `filename`")
 	serverLog      = ioutil.Discard
@@ -136,6 +137,7 @@ func startDefaultServer() error {
 	defaultServer, defaultServerErr = NewServer(
 		"default",
 		"--port", strconv.Itoa(*serverBasePort),
+		"--bind", *serverAddress,
 		"--save", "",
 		"--appendonly", "no")
 	return defaultServerErr
@@ -147,7 +149,7 @@ func DialDefaultServer() (Conn, error) {
 	if err := startDefaultServer(); err != nil {
 		return nil, err
 	}
-	c, err := Dial("tcp", fmt.Sprintf(":%d", *serverBasePort), DialReadTimeout(1*time.Second), DialWriteTimeout(1*time.Second))
+	c, err := Dial("tcp", fmt.Sprintf("%v:%d", *serverAddress, *serverBasePort), DialReadTimeout(1*time.Second), DialWriteTimeout(1*time.Second))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add the option to configure connection keep-alive using the new DialKeepAlive option.

This is set to 5 minutes by default to ensure that half-closed connections are detected.

Without this Pub/Sub connections can get disconnected by the redis server and we will never notice which can potentially deadlock applications.

Also:
* Add --redis-address <address> command line option to tests defaulting to 127.0.0.1. Without this all tests fail on machines with multiple addresses.