### PR TITLE
Disable read timeout for Pub/Sub connections

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -432,6 +432,10 @@ func (pc *pooledConnection) Receive() (reply interface{}, err error) {
 	return pc.c.Receive()
 }
 
+func (pc *pooledConnection) ReceiveNoReadTimeout() (reply interface{}, err error) {
+	return pc.c.ReceiveNoReadTimeout()
+}
+
 type errorConnection struct{ err error }
 
 func (ec errorConnection) Do(string, ...interface{}) (interface{}, error) { return nil, ec.err }
@@ -440,3 +444,4 @@ func (ec errorConnection) Err() error                                     { retu
 func (ec errorConnection) Close() error                                   { return ec.err }
 func (ec errorConnection) Flush() error                                   { return ec.err }
 func (ec errorConnection) Receive() (interface{}, error)                  { return nil, ec.err }
+func (ec errorConnection) ReceiveNoReadTimeout() (interface{}, error)     { return nil, ec.err }

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -102,8 +102,9 @@ func (c PubSubConn) Ping(data string) error {
 // Receive returns a pushed message as a Subscription, Message, PMessage, Pong
 // or error. The return value is intended to be used directly in a type switch
 // as illustrated in the PubSubConn example.
+// It doesn't use the ReadTimeout configured on the pool.
 func (c PubSubConn) Receive() interface{} {
-	reply, err := Values(c.Conn.Receive())
+	reply, err := Values(c.Conn.ReceiveNoReadTimeout())
 	if err != nil {
 		return err
 	}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -38,6 +38,10 @@ type Conn interface {
 
 	// Receive receives a single reply from the Redis server
 	Receive() (reply interface{}, err error)
+
+	// ReceiveNoReadTimeout receives a single reply from the Redis server
+	// without applying any read timeout.
+	ReceiveNoReadTimeout() (reply interface{}, err error)
 }
 
 // Argument is the interface implemented by an object which wants to control how


### PR DESCRIPTION
Due to the nature Pub/Sub connections they highly likely to block on reads for long periods hence it doesn't make sense to apply any read timeout configured on the pool to Pub/Sub connections.